### PR TITLE
Added rudimentary cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(QSerializer LANGUAGES CXX)
+
+# TODO: figure out if we need to add `src/qserializer.h` here.
+add_library(${PROJECT_NAME} INTERFACE src/qserializer.h)
+
+find_package(Qt6 COMPONENTS Core Xml)
+
+if (NOT Qt6_FOUND)
+    find_package(Qt5 COMPONENTS Core REQUIRED Xml REQUIRED)
+endif()
+
+target_include_directories(${PROJECT_NAME} INTERFACE ${${PROJECT_NAME}_SOURCE_DIR})
+target_link_libraries(${PROJECT_NAME} INTERFACE Qt::Core Qt::Xml)


### PR DESCRIPTION
At the moment this doesn't support installation (e.g. to `/usr/include/`) but it should be usable as a git submodule.

The include path is `<QSerializer>` which I'm not sure about (since it might be mistaken for an official qt header) so if that's a problem I'll need to think of a workaround.